### PR TITLE
Modify AccessHandler to pass new tests

### DIFF
--- a/src/AccessHandler.php
+++ b/src/AccessHandler.php
@@ -17,9 +17,12 @@ class AccessHandler
         $this->auth = $auth;
     }
 
-    public function check($role)
+    public function check($roles)
     {
-        return $this->auth->check() && $this->auth->user()->role === $role;
-    }
+        if (is_string($roles)) {
+            $roles = explode('|', $roles);
+        }
 
+        return $this->auth->check() && in_array($this->auth->user()->role, $roles);
+    }
 }


### PR DESCRIPTION
The check() method in AccessHandler now receives an argument ($role) that can be an array of roles or an string of roles separated by '|'. It then checks if the logged user role is one of the roles given.